### PR TITLE
fix: propagate spl signer on buy action

### DIFF
--- a/.changeset/perfect-dogs-exercise.md
+++ b/.changeset/perfect-dogs-exercise.md
@@ -1,0 +1,5 @@
+---
+'@mirrorworld/mirage.core': patch
+---
+
+Propagate SPL signer on buy NFT with SPL token

--- a/packages/core/src/marketplace.ts
+++ b/packages/core/src/marketplace.ts
@@ -1,4 +1,4 @@
-import { Connection, PublicKey, Transaction } from '@solana/web3.js';
+import { Connection, Keypair, PublicKey, Transaction } from '@solana/web3.js';
 import { AnchorProvider, Program, Wallet } from '@project-serum/anchor';
 import { AUCTION_HOUSE_PROGRAM_ID } from './constants';
 import { throwError } from './errors/errors.interface';
@@ -202,7 +202,7 @@ export class Marketplace {
     seller: PublicKey,
     sellerAssociateAccount: PublicKey,
     auctionHouseAddress: PublicKey
-  ): Promise<readonly [Transaction, Receipt]> {
+  ): Promise<readonly [Transaction, Receipt, Keypair[]]> {
     if (!this.program) {
       this.program = await this.loadAuctionHouseProgram();
     }

--- a/packages/core/src/mirage-transactions/buy.ts
+++ b/packages/core/src/mirage-transactions/buy.ts
@@ -157,11 +157,7 @@ export const createBuyTransaction = async (
   const printPurchaseReceiptInstruction = await createPrintPurchaseInstruction(buyer, sellerTradeState, buyerTradeState, purchaseReceipt, purchaseReceiptBump);
   transaction.add(printPurchaseReceiptInstruction);
 
-  if (isSplMint) {
-    transaction.sign(...signers);
-  }
-
-  return [transaction, purchaseReceipt] as const;
+  return [transaction, purchaseReceipt, signers] as const;
 };
 
 const createPrintPurchaseInstruction = async (

--- a/packages/core/src/mirage.ts
+++ b/packages/core/src/mirage.ts
@@ -316,10 +316,14 @@ export class Mirage {
    */
   async buyToken(mint: string, _buyerPrice: number): Promise<readonly [RpcResponseAndContext<any>, ReceiptAddress, TransactionSignature]> {
     const buyerWallet = this.wallet;
-    const [buyTxt, purchaseReceipt] = await this.createBuyTransaction(new PublicKey(mint), _buyerPrice, buyerWallet.publicKey);
+    const [buyTxt, purchaseReceipt, signers] = await this.createBuyTransaction(new PublicKey(mint), _buyerPrice, buyerWallet.publicKey);
 
     buyTxt.recentBlockhash = (await this.connection.getLatestBlockhash()).blockhash;
     buyTxt.feePayer = buyerWallet.publicKey;
+
+    if (signers?.length) {
+      buyTxt.sign(...signers);
+    }
 
     const estimatedCost = (await buyTxt.getEstimatedFee(this.connection)) / LAMPORTS_PER_SOL + Number(_buyerPrice);
     const { value: _balance } = await this.connection.getBalanceAndContext(this.wallet.publicKey);


### PR DESCRIPTION
# Changeset

- Propagate SPL transfer signer on buy NFT with SPL token action, and sign tx after recent blockhash is added 